### PR TITLE
Update GPT3-fine-tune-API-metadata-extraction notebook

### DIFF
--- a/experiments/openai-gpt3-api/GPT3-fine-tune-API-metadata-extraction.ipynb
+++ b/experiments/openai-gpt3-api/GPT3-fine-tune-API-metadata-extraction.ipynb
@@ -17,33 +17,12 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "<OpenAIObject text_completion id=cmpl-7jMCZdObPXH3HW3Q8e31ho9fPUVNv at 0x7fb34084af20> JSON: {\n",
-       "  \"warning\": \"This model version is deprecated. Migrate before January 4, 2024 to avoid disruption of service. Learn more https://platform.openai.com/docs/deprecations\",\n",
-       "  \"id\": \"cmpl-7jMCZdObPXH3HW3Q8e31ho9fPUVNv\",\n",
-       "  \"object\": \"text_completion\",\n",
-       "  \"created\": 1691044459,\n",
-       "  \"model\": \"text-curie-001\",\n",
-       "  \"choices\": [\n",
-       "    {\n",
-       "      \"text\": \"\\n\\nThis is a test.\",\n",
-       "      \"index\": 0,\n",
-       "      \"logprobs\": null,\n",
-       "      \"finish_reason\": \"length\"\n",
-       "    }\n",
-       "  ],\n",
-       "  \"usage\": {\n",
-       "    \"prompt_tokens\": 5,\n",
-       "    \"completion_tokens\": 7,\n",
-       "    \"total_tokens\": 12\n",
-       "  }\n",
-       "}"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Completion(id='cmpl-8T6I3BMP97D6HKkwtlUadVJimIfWw', choices=[CompletionChoice(finish_reason='length', index=0, logprobs=None, text=\". I'm gonna say this is\")], created=1701946383, model='davinci-002', object='text_completion', system_fingerprint=None, usage=CompletionUsage(completion_tokens=7, prompt_tokens=5, total_tokens=12))\n",
+      ". I'm gonna say this is\n"
+     ]
     }
    ],
    "source": [
@@ -54,8 +33,9 @@
     "openai.api_key = os.environ['OPENAI_API_KEY']\n",
     "\n",
     "# test the API connection by making a simple request\n",
-    "response = openai.Completion.create(model=\"text-curie-001\", prompt=\"Say this is a test\", temperature=0, max_tokens=7)\n",
-    "response"
+    "response = openai.completions.create(model=\"davinci-002\", prompt=\"Say this is a test\", temperature=0, max_tokens=7)\n",
+    "print(response)\n",
+    "print(response.choices[0].text)"
    ]
   },
   {
@@ -70,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
    "id": "d035bad1-13d2-4ebe-beee-159991adfe55",
    "metadata": {},
    "outputs": [
@@ -79,34 +59,34 @@
      "output_type": "stream",
      "text": [
       "Creating fine-tune.jsonl\n",
-      "- processing ../../llm-dataset/train/docthes-swe.jsonl\n",
-      "- processing ../../llm-dataset/train/serial-swe.jsonl\n",
-      "- processing ../../llm-dataset/train/thes-swe.jsonl\n",
-      "- processing ../../llm-dataset/train/mono-fin.jsonl\n",
-      "- processing ../../llm-dataset/train/serial-eng.jsonl\n",
-      "- processing ../../llm-dataset/train/thes-fin.jsonl\n",
-      "- processing ../../llm-dataset/train/mono-eng.jsonl\n",
-      "- processing ../../llm-dataset/train/mono-swe.jsonl\n",
-      "- processing ../../llm-dataset/train/thes-eng.jsonl\n",
-      "- processing ../../llm-dataset/train/docthes-eng.jsonl\n",
-      "- processing ../../llm-dataset/train/serial-fin.jsonl\n",
-      "- processing ../../llm-dataset/train/docthes-fin.jsonl\n",
-      "373 records converted\n",
+      "- processing ../../llm-dataset/serial-fin-train.jsonl\n",
+      "- processing ../../llm-dataset/serial-swe-train.jsonl\n",
+      "- processing ../../llm-dataset/docthes-eng-train.jsonl\n",
+      "- processing ../../llm-dataset/docthes-fin-train.jsonl\n",
+      "- processing ../../llm-dataset/thes-fin-train.jsonl\n",
+      "- processing ../../llm-dataset/thes-swe-train.jsonl\n",
+      "- processing ../../llm-dataset/mono-swe-train.jsonl\n",
+      "- processing ../../llm-dataset/docthes-swe-train.jsonl\n",
+      "- processing ../../llm-dataset/mono-eng-train.jsonl\n",
+      "- processing ../../llm-dataset/mono-fin-train.jsonl\n",
+      "- processing ../../llm-dataset/thes-eng-train.jsonl\n",
+      "- processing ../../llm-dataset/serial-eng-train.jsonl\n",
+      "557 records converted\n",
       "\n",
       "Creating validate.jsonl\n",
-      "- processing ../../llm-dataset/test/docthes-swe.jsonl\n",
-      "- processing ../../llm-dataset/test/serial-swe.jsonl\n",
-      "- processing ../../llm-dataset/test/thes-swe.jsonl\n",
-      "- processing ../../llm-dataset/test/mono-fin.jsonl\n",
-      "- processing ../../llm-dataset/test/serial-eng.jsonl\n",
-      "- processing ../../llm-dataset/test/thes-fin.jsonl\n",
-      "- processing ../../llm-dataset/test/mono-eng.jsonl\n",
-      "- processing ../../llm-dataset/test/mono-swe.jsonl\n",
-      "- processing ../../llm-dataset/test/thes-eng.jsonl\n",
-      "- processing ../../llm-dataset/test/docthes-eng.jsonl\n",
-      "- processing ../../llm-dataset/test/serial-fin.jsonl\n",
-      "- processing ../../llm-dataset/test/docthes-fin.jsonl\n",
-      "113 records converted\n",
+      "- processing ../../llm-dataset/mono-swe-test.jsonl\n",
+      "- processing ../../llm-dataset/docthes-swe-test.jsonl\n",
+      "- processing ../../llm-dataset/thes-eng-test.jsonl\n",
+      "- processing ../../llm-dataset/thes-swe-test.jsonl\n",
+      "- processing ../../llm-dataset/thes-fin-test.jsonl\n",
+      "- processing ../../llm-dataset/docthes-fin-test.jsonl\n",
+      "- processing ../../llm-dataset/serial-fin-test.jsonl\n",
+      "- processing ../../llm-dataset/serial-swe-test.jsonl\n",
+      "- processing ../../llm-dataset/mono-fin-test.jsonl\n",
+      "- processing ../../llm-dataset/serial-eng-test.jsonl\n",
+      "- processing ../../llm-dataset/docthes-eng-test.jsonl\n",
+      "- processing ../../llm-dataset/mono-eng-test.jsonl\n",
+      "167 records converted\n",
       "\n"
      ]
     }
@@ -120,11 +100,11 @@
     "COMPLETION_STOP = '\\n###'\n",
     "TRAINFILE = 'fine-tune.jsonl'\n",
     "VALIDATEFILE = 'validate.jsonl'\n",
-    "BASE_MODEL = 'babbage'\n",
-    "MAX_TOKENS = 1450  # empirically chosen so that prepare_data doesn't complain in the cell below\n",
+    "BASE_MODEL = 'babbage-002'\n",
+    "MAX_TOKENS = 12000  # Increased for babbage-002 model\n",
     "\n",
-    "dataset_train_files = glob.glob(\"../../llm-dataset/train/*.jsonl\")\n",
-    "dataset_test_files = glob.glob(\"../../llm-dataset/test/*.jsonl\")\n",
+    "dataset_train_files = glob.glob(\"../../llm-dataset/*-train.jsonl\")\n",
+    "dataset_test_files = glob.glob(\"../../llm-dataset/*-test.jsonl\")\n",
     "\n",
     "encoding = tiktoken.encoding_for_model(BASE_MODEL)\n",
     "\n",
@@ -159,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 9,
    "id": "5cc70c8a-1ab3-4a9e-8d76-b73b718751ca",
    "metadata": {},
    "outputs": [
@@ -169,13 +149,14 @@
      "text": [
       "Analyzing...\n",
       "\n",
-      "- Your file contains 373 prompt-completion pairs\n",
+      "- Your file contains 557 prompt-completion pairs\n",
+      "- There are 7 examples that are very long. These are rows: [231, 257, 258, 268, 333, 468, 504]\n",
+      "For conditional generation, and for classification the examples shouldn't be longer than 2048 tokens.\n",
       "- All prompts end with suffix `\\n\\n###\\n\\n`\n",
-      "- All completions start with prefix ` dc.contributor`. Most of the time you should only add the output data into the completion, without any prefix\n",
       "- All completions end with suffix `\\n###`\n",
       "\n",
       "Based on the analysis we will perform the following actions:\n",
-      "- [Recommended] Remove prefix ` dc.contributor` from all completions [Y/n]: Y\n",
+      "- [Recommended] Remove 7 long examples [Y/n]: Y\n",
       "\n",
       "\n",
       "Your data will be written to a new JSONL file. Proceed [Y/n]: Y\n",
@@ -187,16 +168,17 @@
       "> openai api fine_tunes.create -t \"fine-tune_prepared.jsonl\"\n",
       "\n",
       "After you’ve fine-tuned a model, remember that your prompt has to end with the indicator string `\\n\\n###\\n\\n` for the model to start generating completions, rather than continuing with the prompt. Make sure to include `stop=[\"\\n###\"]` so that the generated texts ends at the expected place.\n",
-      "Once your model starts training, it'll approximately take 7.57 minutes to train a `curie` model, and less for `ada` and `babbage`. Queue will approximately take half an hour per job ahead of you.\n",
+      "Once your model starts training, it'll approximately take 27.87 minutes to train a `curie` model, and less for `ada` and `babbage`. Queue will approximately take half an hour per job ahead of you.\n",
       "Analyzing...\n",
       "\n",
-      "- Your file contains 113 prompt-completion pairs\n",
+      "- Your file contains 167 prompt-completion pairs\n",
+      "- There are 3 examples that are very long. These are rows: [28, 30, 31]\n",
+      "For conditional generation, and for classification the examples shouldn't be longer than 2048 tokens.\n",
       "- All prompts end with suffix `\\n\\n###\\n\\n`\n",
-      "- All completions start with prefix ` dc.contributor`. Most of the time you should only add the output data into the completion, without any prefix\n",
       "- All completions end with suffix `\\n###`\n",
       "\n",
       "Based on the analysis we will perform the following actions:\n",
-      "- [Recommended] Remove prefix ` dc.contributor` from all completions [Y/n]: Y\n",
+      "- [Recommended] Remove 3 long examples [Y/n]: Y\n",
       "\n",
       "\n",
       "Your data will be written to a new JSONL file. Proceed [Y/n]: Y\n",
@@ -208,14 +190,14 @@
       "> openai api fine_tunes.create -t \"validate_prepared.jsonl\"\n",
       "\n",
       "After you’ve fine-tuned a model, remember that your prompt has to end with the indicator string `\\n\\n###\\n\\n` for the model to start generating completions, rather than continuing with the prompt. Make sure to include `stop=[\"\\n###\"]` so that the generated texts ends at the expected place.\n",
-      "Once your model starts training, it'll approximately take 4.0 minutes to train a `curie` model, and less for `ada` and `babbage`. Queue will approximately take half an hour per job ahead of you.\n"
+      "Once your model starts training, it'll approximately take 9.29 minutes to train a `curie` model, and less for `ada` and `babbage`. Queue will approximately take half an hour per job ahead of you.\n"
      ]
     }
    ],
    "source": [
     "# Check that the fine-tuning data set is OK using the prepare_data tool.\n",
-    "# It will complain that all completions start with the same \" dc.contributor\" prefix, this can be ignored.\n",
-    "# We will only use prepare_data as a validation aid and delete the \"prepared\" files that ithelpfully creates.\n",
+    "# We will only use prepare_data as a validation aid and delete the \"prepared\"\n",
+    "# files that it helpfully creates.\n",
     "!openai tools fine_tunes.prepare_data -f fine-tune.jsonl -q\n",
     "!rm -f fine-tune_prepared.jsonl\n",
     "\n",
@@ -225,146 +207,170 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "id": "46b3b6ee-f99e-47e5-a22d-4024dc5de38e",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Upload progress: 100%|████████████████████| 1.78M/1.78M [00:00<00:00, 2.22Git/s]\n",
-      "Uploaded file from fine-tune.jsonl: file-HRqztdzuQaW0k46ZELzDmZQn\n",
-      "Upload progress: 100%|███████████████████████| 565k/565k [00:00<00:00, 813Mit/s]\n",
-      "Uploaded file from validate.jsonl: file-sAAV2B2B3V4jNlnJJsiRalSK\n",
-      "Created fine-tune: ft-XivxNCEeiqRQNiRhSc9RAMfu\n",
-      "Streaming events until fine-tuning is complete...\n",
-      "\n",
-      "(Ctrl-C will interrupt the stream, but not cancel the fine-tune)\n",
-      "[2023-08-03 09:36:07] Created fine-tune: ft-XivxNCEeiqRQNiRhSc9RAMfu\n",
-      "\n",
-      "Stream interrupted (client disconnected).\n",
-      "To resume the stream, run:\n",
-      "\n",
-      "  openai api fine_tunes.follow -i ft-XivxNCEeiqRQNiRhSc9RAMfu\n",
-      "\n"
-     ]
+     "data": {
+      "text/plain": [
+       "FileObject(id='file-tiZAgq70qPmQa7KDYHFP5Bzg', bytes=2970399, created_at=1701947205, filename='fine-tune.jsonl', object='file', purpose='fine-tune', status='uploaded', status_details=None)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# OpenAI API and client have changed, now finetuning can or needs to be done\n",
+    "# with Python code, not CLI client\n",
+    "\n",
+    "# Upload training data\n",
+    "\n",
+    "upload_response = openai.files.create(\n",
+    "    file=open(TRAINFILE, \"rb\"),\n",
+    "    purpose=\"fine-tune\"\n",
+    ")\n",
+    "trainfile_id = upload_response.id\n",
+    "upload_response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c4352c4f-276f-4893-a5c2-acb94572b4d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "FineTuningJob(id='ftjob-f3Plu07lCRlZlZYaWjCiWKLR', created_at=1701947281, error=None, fine_tuned_model=None, finished_at=None, hyperparameters=Hyperparameters(n_epochs='auto', batch_size='auto', learning_rate_multiplier='auto'), model='babbage-002', object='fine_tuning.job', organization_id='org-5QEUW2DacClOLTNQvTEKMHdV', result_files=[], status='validating_files', trained_tokens=None, training_file='file-tiZAgq70qPmQa7KDYHFP5Bzg', validation_file=None)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "# Perform the actual finetuning via the API. This can take a while, there can be a long queue.\n",
-    "!openai api fine_tunes.create -t fine-tune.jsonl -v validate.jsonl -m {BASE_MODEL}"
+    "\n",
+    "openai.fine_tuning.jobs.create(\n",
+    "    training_file=trainfile_id,\n",
+    "    model=\"babbage-002\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "c4352c4f-276f-4893-a5c2-acb94572b4d0",
+   "id": "0cc0c7fb-3785-4223-a4ff-97f4d058afd1",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2023-08-03 09:36:07] Created fine-tune: ft-XivxNCEeiqRQNiRhSc9RAMfu\n",
-      "[2023-08-03 11:48:36] Fine-tune costs $1.39\n",
-      "[2023-08-03 11:48:36] Fine-tune enqueued. Queue number: 6\n",
-      "[2023-08-03 11:50:31] Fine-tune is in the queue. Queue number: 5\n",
-      "[2023-08-03 11:50:33] Fine-tune is in the queue. Queue number: 4\n",
-      "[2023-08-03 11:51:17] Fine-tune is in the queue. Queue number: 3\n",
-      "[2023-08-03 11:51:40] Fine-tune is in the queue. Queue number: 2\n",
-      "[2023-08-03 11:52:17] Fine-tune is in the queue. Queue number: 1\n",
-      "[2023-08-03 11:52:31] Fine-tune is in the queue. Queue number: 0\n",
-      "[2023-08-03 11:52:35] Fine-tune started\n",
-      "[2023-08-03 11:55:03] Completed epoch 1/4\n",
-      "[2023-08-03 11:57:06] Completed epoch 2/4\n",
-      "[2023-08-03 11:59:09] Completed epoch 3/4\n",
-      "[2023-08-03 12:01:13] Completed epoch 4/4\n",
-      "[2023-08-03 12:01:33] Uploaded model: babbage:ft-personal-2023-08-03-09-01-32\n",
-      "[2023-08-03 12:01:34] Uploaded result file: file-l7O6EqcqDWgaZyvl7qyrKSfA\n",
-      "[2023-08-03 12:01:34] Fine-tune succeeded\n",
-      "\n",
-      "Job complete! Status: succeeded 🎉\n",
-      "Try out your fine-tuned model:\n",
-      "\n",
-      "openai api completions.create -m babbage:ft-personal-2023-08-03-09-01-32 -p <YOUR_PROMPT>\n"
-     ]
+     "data": {
+      "text/plain": [
+       "[FineTuningJobEvent(id='ftevent-uZAdFSd2qHjZsgf2DOe4LwN9', created_at=1701949004, level='info', message='The job has successfully completed', object='fine_tuning.job.event', data={}, type='message'),\n",
+       " FineTuningJobEvent(id='ftevent-ChGZH2rgFtkoibq4ygIhNu5G', created_at=1701949002, level='info', message='New fine-tuned model created: ft:babbage-002:personal::8T6yHGdp', object='fine_tuning.job.event', data={}, type='message'),\n",
+       " FineTuningJobEvent(id='ftevent-5w8o0kPU98fSSZ6BHZXWU3HK', created_at=1701948982, level='info', message='Step 1601/1671: training loss=0.47', object='fine_tuning.job.event', data={'step': 1601, 'train_loss': 0.47158852219581604, 'train_mean_token_accuracy': 0.8634920716285706}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-v36VuJqsnsZHi7MkVEZctCPA', created_at=1701948963, level='info', message='Step 1501/1671: training loss=0.22', object='fine_tuning.job.event', data={'step': 1501, 'train_loss': 0.2230607271194458, 'train_mean_token_accuracy': 0.9497487545013428}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-FGzcKzW5Gyione7THZdWqRgk', created_at=1701948944, level='info', message='Step 1401/1671: training loss=0.09', object='fine_tuning.job.event', data={'step': 1401, 'train_loss': 0.09154736250638962, 'train_mean_token_accuracy': 0.9793103337287903}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-ia3if0ujrWRnuoVevAZlSb6d', created_at=1701948927, level='info', message='Step 1301/1671: training loss=0.17', object='fine_tuning.job.event', data={'step': 1301, 'train_loss': 0.1699811965227127, 'train_mean_token_accuracy': 0.9609755873680115}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-1y0mOi0wCvBLmyMScG75s1Xt', created_at=1701948909, level='info', message='Step 1201/1671: training loss=0.04', object='fine_tuning.job.event', data={'step': 1201, 'train_loss': 0.038225434720516205, 'train_mean_token_accuracy': 0.9931972622871399}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-66DJetAbtK5rxFHyUGCeASMp', created_at=1701948889, level='info', message='Step 1101/1671: training loss=0.26', object='fine_tuning.job.event', data={'step': 1101, 'train_loss': 0.2551744878292084, 'train_mean_token_accuracy': 0.9345238208770752}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-oRy5qlqWXEYAb6guqxCBmBwM', created_at=1701948870, level='info', message='Step 1001/1671: training loss=0.64', object='fine_tuning.job.event', data={'step': 1001, 'train_loss': 0.6393063068389893, 'train_mean_token_accuracy': 0.8478260636329651}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-Dal59WVeiVFxKq0e5ZfIJVgt', created_at=1701948851, level='info', message='Step 901/1671: training loss=0.28', object='fine_tuning.job.event', data={'step': 901, 'train_loss': 0.2831694483757019, 'train_mean_token_accuracy': 0.9352226853370667}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-P1OjDFgpytJ36x7bOwzssbLj', created_at=1701948835, level='info', message='Step 801/1671: training loss=0.13', object='fine_tuning.job.event', data={'step': 801, 'train_loss': 0.13209879398345947, 'train_mean_token_accuracy': 0.9715909361839294}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-Cs7nx9dD8KONPRqE8Ph4HLYf', created_at=1701948816, level='info', message='Step 701/1671: training loss=0.37', object='fine_tuning.job.event', data={'step': 701, 'train_loss': 0.36541152000427246, 'train_mean_token_accuracy': 0.9145299196243286}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-1L9YXz3E7Fwc6kAtatTAjYdw', created_at=1701948797, level='info', message='Step 601/1671: training loss=0.48', object='fine_tuning.job.event', data={'step': 601, 'train_loss': 0.4809528887271881, 'train_mean_token_accuracy': 0.8917526006698608}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-bmxk1YI3ywNWQx0NgTgbbmgD', created_at=1701948777, level='info', message='Step 501/1671: training loss=0.07', object='fine_tuning.job.event', data={'step': 501, 'train_loss': 0.07233993709087372, 'train_mean_token_accuracy': 0.9803149700164795}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-CHLsJp0MgJNyFHGd0y2Nmuui', created_at=1701948759, level='info', message='Step 401/1671: training loss=0.17', object='fine_tuning.job.event', data={'step': 401, 'train_loss': 0.16854888200759888, 'train_mean_token_accuracy': 0.9580419659614563}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-TnXjtN0Wg1o3FRvxsauEslKw', created_at=1701948742, level='info', message='Step 301/1671: training loss=0.59', object='fine_tuning.job.event', data={'step': 301, 'train_loss': 0.5917478799819946, 'train_mean_token_accuracy': 0.8647342920303345}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-aIeDZtKSrSxcsmXQQtgtTG3W', created_at=1701948723, level='info', message='Step 201/1671: training loss=1.32', object='fine_tuning.job.event', data={'step': 201, 'train_loss': 1.3232041597366333, 'train_mean_token_accuracy': 0.7010869383811951}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-mpDBEJGpQf0MPUjvRh6FJIHL', created_at=1701948704, level='info', message='Step 101/1671: training loss=0.00', object='fine_tuning.job.event', data={'step': 101, 'train_loss': 0.0, 'train_mean_token_accuracy': 0.0}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-WmOcvI85q3eHXNWFqty5TpXW', created_at=1701948685, level='info', message='Step 1/1671: training loss=2.08', object='fine_tuning.job.event', data={'step': 1, 'train_loss': 2.075146436691284, 'train_mean_token_accuracy': 0.6639344096183777}, type='metrics'),\n",
+       " FineTuningJobEvent(id='ftevent-7y59GvsMcQrw8bQ13zgY0ewZ', created_at=1701948624, level='info', message='Fine-tuning job started', object='fine_tuning.job.event', data=None, type='message')]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "!openai api fine_tunes.follow -i ft-XivxNCEeiqRQNiRhSc9RAMfu"
+    "fine_tuning_job_id = openai.fine_tuning.jobs.list(limit=10).data[0].id\n",
+    "openai.fine_tuning.jobs.list_events(fine_tuning_job_id=fine_tuning_job_id, limit=20).data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "0cc0c7fb-3785-4223-a4ff-97f4d058afd1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# copy the model name from above output and store it in a variable\n",
-    "model_name = \"babbage:ft-personal-2023-08-03-09-01-32\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 16,
    "id": "0875b0c7-b561-48c1-a9b8-c115f6a7537e",
    "metadata": {},
    "outputs": [
     {
+     "data": {
+      "text/plain": [
+       "'ft:babbage-002:personal::8T6yHGdp'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# store the model name from above fine tuning job\n",
+    "\n",
+    "model_name = openai.fine_tuning.jobs.retrieve(fine_tuning_job_id).fine_tuned_model\n",
+    "model_name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Testing on https://www.doria.fi/handle/10024/181210 with PDF https://www.doria.fi/bitstream/handle/10024/181210/koskinen_monika.pdf\n",
+      "Testing on https://www.theseus.fi/handle/10024/498793 with PDF https://www.theseus.fi/bitstream/handle/10024/498793/Eklund_Liz_Marjanen_Emma.pdf\n",
       "---\n",
       "Curated metadata:\n",
-      "dc.contributor.author: Koskinen, Monika\n",
-      "dc.contributor.faculty: Faculty of Education and Welfare Studies\n",
-      "dc.contributor.faculty: Fakulteten för pedagogik och välfärdsstudier\n",
-      "dc.contributor.faculty: Kasvatustieteiden ja hyvinvointialojen tiedekunta\n",
-      "dc.contributor.opponent: Professor Ulrica Hörberg, Linnéuniversitetet, Växjö, Sverige\n",
-      "dc.contributor.organization: Åbo Akademi\n",
-      "dc.contributor.supervisor: Professor Camilla Koskinen, Universitetet i Stavanger, Stavanger, Norge\n",
-      "dc.contributor.supervisor: TD Mårten Björkgren, Åbo Akademi, Vasa\n",
-      "dc.date.issued: 2021-06-17\n",
-      "dc.format.content: fulltext\n",
-      "dc.identifier.isbn: 978-951-765-993-2\n",
-      "dc.identifier.urn: URN:ISBN:978-951-765-993-2\n",
-      "dc.language.iso: swe\n",
-      "dc.publisher: Åbo Akademis förlag - Åbo Akademi University Press\n",
-      "dc.relation.isbn: 978-951-765-992-5\n",
-      "dc.title: Hälsans tomrum : En hermeneutisk studie om försakelsens betydelse för hälsan\n",
-      "dc.title.alternative: A void for health - A hermeneutic study of the significance of renunciation for health\n",
-      "dc.type.coar: väitöskirja\n",
-      "dc.type.okm: G4 Doctoral dissertation (monograph) {en}\n",
-      "dc.type.okm: G4 Monografiavhandling {sv}\n",
-      "dc.type.okm: G4 Monografiaväitöskirja {fi}\n",
-      "dc.type.ontasot: Doctoral dissertation (monograph)\n",
-      "dc.type.ontasot: Doktorsavhandling (monografi)\n",
-      "dc.type.ontasot: Väitöskirja (monografia)\n",
+      "Author: Eklund, Liz\n",
+      "Author: Marjanen, Emma\n",
+      "Organization: Högskolan på Åland\n",
+      "Issued: 2021\n",
+      "URN: URN:NBN:fi:amk-2021052110375\n",
+      "Language: swe\n",
+      "Publisher: Högskolan på Åland\n",
+      "ISSN (online): 1458-1531\n",
+      "Degree program: Utbildningsprogrammet för företagsekonomi\n",
+      "Discipline: Företagsekonomi, förvaltning och marknadsföring\n",
+      "Title: Hållbara inköp hos två åländska företag : verksamma inom plastindustrin\n",
+      "Alternative title: Sustainable Purchases at two Åland Companies - active in the plastics industry\n",
+      "COAR type: bachelor thesis\n",
+      "OKM type: G1 Ammattikorkeakoulututkinnon opinnäytetyö, kandidaatintyö\n",
+      "Thesis level: AMK-opinnäytetyö\n",
       "---\n",
       "Generated metadata:\n",
-      "dc.contributor.author: Koskinen, Monika\n",
-      "dc.contributor.faculty: Fakulteten för pedagogik och välfärdsstudier\n",
-      "dc.contributor.opponent: Docent Anna-Karin Eriksson, Uppsala universitet\n",
-      "dc.contributor.organization: Åbo Akademi\n",
-      "dc.contributor.supervisor: Docent Anna-Karin Eriksson, Uppsala universitet\n",
-      "dc.date.issued: 2021-11-23\n",
-      "dc.format.content: fulltext\n",
-      "dc.identifier.isbn: 978-951-765-964-2\n",
-      "dc.identifier.urn: URN:ISBN:978-951-765-964-2\n",
-      "dc.language.iso: swe\n",
-      "dc.publisher: Åbo Akademis förlag - Åbo Akademi University Press\n",
-      "dc.relation.isbn: 978-951-765-963-5\n",
-      "dc.title: Hälsans tomrum : En hermeneutisk studie om försakelsens betydelse för hälsan\n",
-      "dc.type.coar: väitöskirja\n",
-      "dc.type.okm: G4 Doctoral dissertation (monograph) {en}\n",
-      "dc.type.okm: G4 Monografiavhandling {sv}\n",
-      "dc.type.okm: G4 Monografiaväitöskirja {fi}\n",
-      "dc.type.ontasot: Doctoral dissertation (monograph)\n",
-      "dc.type.ontasot: Doktorsavhandling (monografi)\n",
-      "dc.type.ontasot: Väitöskirja (monografia)\n"
+      "Author: Eklund, Emma\n",
+      "Author: Marjanen, Emma\n",
+      "Organization: Högskolan på Åland\n",
+      "Issued: 2021\n",
+      "URN: URN:NBN:fi-fe2021051922434\n",
+      "Language: swe\n",
+      "Publisher: Högskolan på Åland\n",
+      "ISSN (online): 1458-1531\n",
+      "Degree program: Företagsekonomi\n",
+      "Discipline: Ekonomi\n",
+      "Title: Hållbara inköp hos två åländska företag : verksamma inom plastindustrin\n",
+      "Alternative title: Sustainable Purchases at two Åland Companies - active in the plastics industry\n",
+      "COAR type: bachelor thesis\n",
+      "OKM type: G1 Ammattikorkeakoulututkinnon opinnäytetyö, kandidaatintyö\n",
+      "Thesis level: AMK-opinnäytetyö\n"
      ]
     }
    ],
@@ -374,13 +380,13 @@
     "import random\n",
     "\n",
     "def get_completions(text):\n",
-    "    response = openai.Completion.create(model=model_name,\n",
+    "    response = openai.completions.create(\n",
+    "                                    model=model_name,\n",
     "                                    prompt=truncate_text(text) + PROMPT_SUFFIX,\n",
     "                                    temperature=0,  # no fooling around!\n",
-    "                                    max_tokens=2048 - MAX_TOKENS - 5, # should be plenty\n",
+    "                                    max_tokens=2048, # should be very plenty\n",
     "                                    stop=[COMPLETION_STOP])  # stop at ###\n",
-    "    return response['choices'][0]['text'].strip()\n",
-    "\n",
+    "    return response.choices[0].text.strip()\n",
     "\n",
     "test_set_file = random.choice(dataset_test_files)\n",
     "with open(test_set_file) as testfile:\n",
@@ -398,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 21,
    "id": "048e1e68-304f-4885-9ba9-5e85c92dda0d",
    "metadata": {},
    "outputs": [
@@ -406,44 +412,44 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "generating metadata for ../../llm-dataset/test/docthes-swe.jsonl into gpt3-docthes-swe.jsonl\n",
-      "completed 5 records\n",
-      "\n",
-      "generating metadata for ../../llm-dataset/test/serial-swe.jsonl into gpt3-serial-swe.jsonl\n",
-      "completed 7 records\n",
-      "\n",
-      "generating metadata for ../../llm-dataset/test/thes-swe.jsonl into gpt3-thes-swe.jsonl\n",
-      "completed 10 records\n",
-      "\n",
-      "generating metadata for ../../llm-dataset/test/mono-fin.jsonl into gpt3-mono-fin.jsonl\n",
+      "generating metadata for ../../llm-dataset/mono-swe-test.jsonl into gpt3-mono-swe-test.jsonl\n",
       "completed 8 records\n",
       "\n",
-      "generating metadata for ../../llm-dataset/test/serial-eng.jsonl into gpt3-serial-eng.jsonl\n",
-      "completed 9 records\n",
+      "generating metadata for ../../llm-dataset/docthes-swe-test.jsonl into gpt3-docthes-swe-test.jsonl\n",
+      "completed 5 records\n",
       "\n",
-      "generating metadata for ../../llm-dataset/test/thes-fin.jsonl into gpt3-thes-fin.jsonl\n",
-      "completed 20 records\n",
+      "generating metadata for ../../llm-dataset/thes-eng-test.jsonl into gpt3-thes-eng-test.jsonl\n",
+      "completed 14 records\n",
       "\n",
-      "generating metadata for ../../llm-dataset/test/mono-eng.jsonl into gpt3-mono-eng.jsonl\n",
-      "completed 9 records\n",
-      "\n",
-      "generating metadata for ../../llm-dataset/test/mono-swe.jsonl into gpt3-mono-swe.jsonl\n",
-      "completed 0 records\n",
-      "\n",
-      "generating metadata for ../../llm-dataset/test/thes-eng.jsonl into gpt3-thes-eng.jsonl\n",
-      "completed 11 records\n",
-      "\n",
-      "generating metadata for ../../llm-dataset/test/docthes-eng.jsonl into gpt3-docthes-eng.jsonl\n",
+      "generating metadata for ../../llm-dataset/thes-swe-test.jsonl into gpt3-thes-swe-test.jsonl\n",
       "completed 16 records\n",
       "\n",
-      "generating metadata for ../../llm-dataset/test/serial-fin.jsonl into gpt3-serial-fin.jsonl\n",
-      "completed 11 records\n",
+      "generating metadata for ../../llm-dataset/thes-fin-test.jsonl into gpt3-thes-fin-test.jsonl\n",
+      "completed 21 records\n",
       "\n",
-      "generating metadata for ../../llm-dataset/test/docthes-fin.jsonl into gpt3-docthes-fin.jsonl\n",
-      "completed 7 records\n",
+      "generating metadata for ../../llm-dataset/docthes-fin-test.jsonl into gpt3-docthes-fin-test.jsonl\n",
+      "completed 9 records\n",
       "\n",
-      "CPU times: user 824 ms, sys: 26.4 ms, total: 851 ms\n",
-      "Wall time: 6min 50s\n"
+      "generating metadata for ../../llm-dataset/serial-fin-test.jsonl into gpt3-serial-fin-test.jsonl\n",
+      "completed 18 records\n",
+      "\n",
+      "generating metadata for ../../llm-dataset/serial-swe-test.jsonl into gpt3-serial-swe-test.jsonl\n",
+      "completed 14 records\n",
+      "\n",
+      "generating metadata for ../../llm-dataset/mono-fin-test.jsonl into gpt3-mono-fin-test.jsonl\n",
+      "completed 17 records\n",
+      "\n",
+      "generating metadata for ../../llm-dataset/serial-eng-test.jsonl into gpt3-serial-eng-test.jsonl\n",
+      "completed 17 records\n",
+      "\n",
+      "generating metadata for ../../llm-dataset/docthes-eng-test.jsonl into gpt3-docthes-eng-test.jsonl\n",
+      "completed 15 records\n",
+      "\n",
+      "generating metadata for ../../llm-dataset/mono-eng-test.jsonl into gpt3-mono-eng-test.jsonl\n",
+      "completed 13 records\n",
+      "\n",
+      "CPU times: user 2.95 s, sys: 54 ms, total: 3 s\n",
+      "Wall time: 10min 7s\n"
      ]
     }
    ],
@@ -470,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 23,
    "id": "e947bea0-1f37-44b4-9a21-75de1278ac9c",
    "metadata": {},
    "outputs": [
@@ -478,7 +484,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Overall similarity: 0.7886717084961832\n"
+      "Overall similarity: 0.721646225749584\n"
      ]
     }
    ],
@@ -491,7 +497,7 @@
     "data = []\n",
     "for test_file in dataset_test_files:\n",
     "    gen_file = \"gpt3-\" + os.path.basename(test_file)\n",
-    "    _, subset, lang = os.path.splitext(gen_file)[0].split('-')\n",
+    "    _, subset, lang, _ = os.path.splitext(gen_file)[0].split('-')\n",
     "    with open(gen_file) as gfile:\n",
     "        for line in gfile:\n",
     "            rec = json.loads(line)\n",
@@ -505,7 +511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 24,
    "id": "cd3d989e-1b65-42a1-bffd-07ed4dc7ab46",
    "metadata": {},
    "outputs": [
@@ -513,14 +519,14 @@
      "data": {
       "text/plain": [
        "subset\n",
-       "docthes    0.820709\n",
-       "mono       0.665335\n",
-       "serial     0.763267\n",
-       "thes       0.834662\n",
+       "docthes    0.778195\n",
+       "mono       0.655294\n",
+       "serial     0.633551\n",
+       "thes       0.823571\n",
        "Name: similarity, dtype: float64"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -531,7 +537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 25,
    "id": "0b9fb423-e6f1-4e07-928e-d2f0649f808c",
    "metadata": {},
    "outputs": [
@@ -539,13 +545,13 @@
      "data": {
       "text/plain": [
        "lang\n",
-       "eng    0.768135\n",
-       "fin    0.784264\n",
-       "swe    0.839895\n",
+       "eng    0.671907\n",
+       "fin    0.743314\n",
+       "swe    0.757140\n",
        "Name: similarity, dtype: float64"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -556,7 +562,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 26,
    "id": "fc925e69-5920-41a6-a0e9-43b492cbcd7b",
    "metadata": {},
    "outputs": [
@@ -564,21 +570,22 @@
      "data": {
       "text/plain": [
        "subset   lang\n",
-       "docthes  eng     0.841979\n",
-       "         fin     0.803360\n",
-       "         swe     0.776932\n",
-       "mono     eng     0.674078\n",
-       "         fin     0.655498\n",
-       "serial   eng     0.762734\n",
-       "         fin     0.735521\n",
-       "         swe     0.807553\n",
-       "thes     eng     0.742101\n",
-       "         fin     0.855895\n",
-       "         swe     0.894015\n",
+       "docthes  eng     0.786059\n",
+       "         fin     0.792288\n",
+       "         swe     0.729233\n",
+       "mono     eng     0.645852\n",
+       "         fin     0.637751\n",
+       "         swe     0.707916\n",
+       "serial   eng     0.526967\n",
+       "         fin     0.703911\n",
+       "         swe     0.672509\n",
+       "thes     eng     0.749791\n",
+       "         fin     0.841554\n",
+       "         swe     0.864525\n",
        "Name: similarity, dtype: float64"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -612,7 +619,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
OpenAI client has changed since running this notebook (v1.0 was released 6.11.2023, and now the latest is already v1.3.7).

Also the babbage model [has been deprecated and will shutdown 4.1.2024](https://platform.openai.com/docs/deprecations/base-gpt-models), so I updated to use babbage-002 base model as recommended.

For my run the results got worse (overall similarity 0.7886 -> 0.7216) but at this point I think it does not matter so much.

BTW, at openai.com one can now see logs and training loss of the fine-tune run: 
![image](https://github.com/NatLibFi/FinGreyLit/assets/34240031/3cf87c62-ae20-4953-9836-f8abf4804ab2)
